### PR TITLE
Dice rolling and material collecting methods

### DIFF
--- a/KrampitzKreutzwiserSettlersOfCatan/src/krampitzkreutzwisersettlersofcatan/GamePanel.java
+++ b/KrampitzKreutzwiserSettlersOfCatan/src/krampitzkreutzwisersettlersofcatan/GamePanel.java
@@ -180,10 +180,29 @@ public class GamePanel extends javax.swing.JPanel {
     }
     
     /**
-     * Roll both of the 6 sided dice and
+     * Roll both of the 6 sided dice and act according to the roll.
+     * 7 Will trigger thief movement, and other values give resources.
+     * The roll is done as 2 1d6 rolls to create the same number rarity as 2 dice give
      */
     private void diceRoll() {
-    
+        int roll; // Holds the dice roll
+        
+        // Roll the first dice
+        roll = (int)(Math.random()*6) + 1;
+        // Roll the second dice and add to the total
+        roll += (int)(Math.random()*6) + 1;
+        
+        System.out.println("Rolled a " + roll);
+        
+        // Act on the dice roll
+        if (roll == 7) { // Move the thief on a 7
+            // TODO: Allow player to move thief
+        }
+        else { // Otherwise collect materials
+            // Search for tiles with the number rolled as their harvest number,
+            // And give players the materials
+            collectMaterials(roll);
+        }
     }
     
     /**
@@ -192,7 +211,30 @@ public class GamePanel extends javax.swing.JPanel {
      * @param harvestNumber The harvesting roll that selects which tiles to harvest from
      */
     private void collectMaterials(int harvestNumber) {
-    
+        NodeSettlement settlement; // Hold the settlement being searched
+
+        // Check every settlement to see if the player owns it and if any 
+        // adjacent tiles have the harvesting number
+        for (int i = 0; i < 54; i++) {
+            // Store the node
+            settlement = settlementNodes.get(i);
+        
+            // If the settlement's owner matches the current player 
+            if (settlement.getPlayer() == currentPlayer) {
+                // Search the tiles around the node
+                for (int j = 1; j <= 3; j++) {
+                    // If the tile has the same harvest number
+                    // And doesnt have the thief on it
+                    if (settlement.getTile(j).getHarvestRollNum() == harvestNumber
+                            && settlement.getTile(j).hasThief() == false) {
+                        // Give the player the tile's resource
+                        cards[currentPlayer].add(settlement.getTile(j).getType());
+                        System.out.println("Gave player " + currentPlayer + " a type " 
+                                + settlement.getTile(j).getType() + " resource");
+                    }
+                }
+            }
+        }
     }
     
     //overrides paintComponent in JPanel class

--- a/KrampitzKreutzwiserSettlersOfCatan/src/krampitzkreutzwisersettlersofcatan/GamePanel.java
+++ b/KrampitzKreutzwiserSettlersOfCatan/src/krampitzkreutzwisersettlersofcatan/GamePanel.java
@@ -207,20 +207,22 @@ public class GamePanel extends javax.swing.JPanel {
     
     /**
      * Collect resources from tiles with the passed harvest roll number and give
-     * the collected resources to the current player
+     * the collected resources to the owner of the settlements collecting them
      * @param harvestNumber The harvesting roll that selects which tiles to harvest from
      */
     private void collectMaterials(int harvestNumber) {
         NodeSettlement settlement; // Hold the settlement being searched
-
-        // Check every settlement to see if the player owns it and if any 
+        int player; // The id of the settlement's owner
+        
+        // Check every settlement to see if a player owns it and if any 
         // adjacent tiles have the harvesting number
         for (int i = 0; i < 54; i++) {
             // Store the node
             settlement = settlementNodes.get(i);
         
-            // If the settlement's owner matches the current player 
-            if (settlement.getPlayer() == currentPlayer) {
+            // Make sure the settlement is owned
+            player = settlement.getPlayer();
+            if (player != 0) {
                 // Search the tiles around the node
                 for (int j = 1; j <= 3; j++) {
                     // If the tile has the same harvest number
@@ -228,8 +230,8 @@ public class GamePanel extends javax.swing.JPanel {
                     if (settlement.getTile(j).getHarvestRollNum() == harvestNumber
                             && settlement.getTile(j).hasThief() == false) {
                         // Give the player the tile's resource
-                        cards[currentPlayer].add(settlement.getTile(j).getType());
-                        System.out.println("Gave player " + currentPlayer + " a type " 
+                        cards[player].add(settlement.getTile(j).getType());
+                        System.out.println("Gave player " + player + " a type " 
                                 + settlement.getTile(j).getType() + " resource");
                     }
                 }


### PR DESCRIPTION
Added dice rolling and material collecting methods.

The dice roll is done with 2 rolls from 1-6 to replicate the number rarities that 2 dice give to the board game

Material collection is a separate method from the dice rolling, and searches all of the settlement nodes for settlements that the current player owns. For every settlement the player owns, it checks each tile the node references to compare the harvest number to the dice roll, and makes sure the thief is not on the tile. If the number matches and there is no thief, the material is added to the player's card list. 